### PR TITLE
fix: handling of multiple`InstrumentationNodeModuleDefinition` with the same name

### DIFF
--- a/packages/esbuild-plugin-node/src/common.ts
+++ b/packages/esbuild-plugin-node/src/common.ts
@@ -23,6 +23,7 @@ export function wrapModule(
     moduleVersion,
     oTelInstrumentationPackage,
     oTelInstrumentationClass,
+    instrumentationName,
     oTelInstrumentationConstructorArgs = '',
   }: ModuleParams
 ) {
@@ -31,37 +32,42 @@ export function wrapModule(
   ${originalSource}
 })(...arguments);
 {
-  let mod = module.exports;
-
-  const { satisfies } = require('semver');
-  const { ${oTelInstrumentationClass} } = require('${oTelInstrumentationPackage}');
   const { diag } = require('@opentelemetry/api');
-  const instrumentations = new ${oTelInstrumentationClass}(${oTelInstrumentationConstructorArgs}).getModuleDefinitions();
 
-  for (const instrumentation of instrumentations) {
-    if (!instrumentation.supportedVersions.some(v => satisfies('${moduleVersion}', v))) {
-      diag.debug('Skipping instrumentation ${oTelInstrumentationClass}, because module version ${moduleVersion} does not match supported versions ' + instrumentation.supportedVersions.join(','));
-      continue;
-    }
+  try {
+    let mod = module.exports;
 
-    if (instrumentation.patch) {
-      diag.debug('Applying instrumentation patch ' + instrumentation.name + ' via esbuild-plugin-node');
-      mod = instrumentation.patch(mod)
-    }
+    const { satisfies } = require('semver');
+    const { ${oTelInstrumentationClass} } = require('${oTelInstrumentationPackage}');
+    const instrumentations = new ${oTelInstrumentationClass}(${oTelInstrumentationConstructorArgs}).getModuleDefinitions();
 
-    if (instrumentation.files?.length) {
-      for (const file of instrumentation.files.filter(f => f.name === '${path}')) {
-        if (!file.supportedVersions.some(v => satisfies('${moduleVersion}', v))) {
-          diag.debug('Skipping instrumentation for ${path}@${moduleVersion} because it does not match supported versions ' + file.supportedVersions.join(','));
-          continue;
+    for (const instrumentation of instrumentations.filter(i => i.name === '${instrumentationName}')) {
+      if (!instrumentation.supportedVersions.some(v => satisfies('${moduleVersion}', v))) {
+        diag.debug('Skipping instrumentation ${instrumentationName}, because module version ${moduleVersion} does not match supported versions ' + instrumentation.supportedVersions.join(','));
+        continue;
+      }
+
+      if (instrumentation.patch) {
+        diag.debug('Applying instrumentation patch ${instrumentationName} via esbuild-plugin-node');
+        mod = instrumentation.patch(mod)
+      }
+
+      if (instrumentation.files?.length) {
+        for (const file of instrumentation.files.filter(f => f.name === '${path}')) {
+          if (!file.supportedVersions.some(v => satisfies('${moduleVersion}', v))) {
+            diag.debug('Skipping instrumentation for ${path}@${moduleVersion} because it does not match supported versions' + file.supportedVersions.join(','));
+            continue;
+          }
+          diag.debug('Applying instrumentation patch to ${path}@${moduleVersion} via esbuild-plugin-node');
+          mod = file.patch(mod, '${moduleVersion}');
         }
-        diag.debug('Applying instrumentation patch to ${path}@${moduleVersion} via esbuild-plugin-node');
-        mod = file.patch(mod, '${moduleVersion}');
       }
     }
-  }
 
-  module.exports = mod;
+    module.exports = mod;
+  } catch (e) {
+    diag.error('Error applying instrumentation ${instrumentationName}', e);
+  }
 }
 `;
 }

--- a/packages/esbuild-plugin-node/src/plugin.ts
+++ b/packages/esbuild-plugin-node/src/plugin.ts
@@ -118,7 +118,6 @@ export function openTelemetryPlugin(
                 extractedModule.path || ''
               ),
               moduleVersion: pluginData.moduleVersion,
-              instrumentationName: pluginData.instrumentationName,
               oTelInstrumentationClass: config.oTelInstrumentationClass,
               oTelInstrumentationPackage: config.oTelInstrumentationPackage,
               oTelInstrumentationConstructorArgs:

--- a/packages/esbuild-plugin-node/src/plugin.ts
+++ b/packages/esbuild-plugin-node/src/plugin.ts
@@ -118,6 +118,7 @@ export function openTelemetryPlugin(
                 extractedModule.path || ''
               ),
               moduleVersion: pluginData.moduleVersion,
+              instrumentationName: pluginData.instrumentationName,
               oTelInstrumentationClass: config.oTelInstrumentationClass,
               oTelInstrumentationPackage: config.oTelInstrumentationPackage,
               oTelInstrumentationConstructorArgs:


### PR DESCRIPTION
When there are multiple `InstrumentationNodeModuleDefinition`s the  urrent implementation chooses one of the`InstrumentationNodeModuleDefinition`s in bunle-time and then in runtime selects it by name. This breaks when there are multiple `InstrumentationNodeModuleDefinition`s with the same name, as the wrong one may be selected. 

This is the case with:
`mongodb` - https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-mongodb/src/instrumentation.ts#L96
`winston` - https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-winston/src/instrumentation.ts#L48
`socket.io` - https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/instrumentation-socket.io/src/socket.io.ts#L218
`generic-pool` - https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-generic-pool/src/instrumentation.ts#L43

This PR approaches the problem analogically to how `instrumentation.files` are handled. By iterating over the instrumentation in runtime and applying the ones with matching version.